### PR TITLE
Replace ConfigurationManager usage with IConfiguration

### DIFF
--- a/AnchorSafeWebApi/AnchorSafeWebApi.csproj
+++ b/AnchorSafeWebApi/AnchorSafeWebApi.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.0" />
     <PackageReference Include="SkiaSharp" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
   </ItemGroup>
 

--- a/AnchorSafeWebApi/Controllers/AuthController.cs
+++ b/AnchorSafeWebApi/Controllers/AuthController.cs
@@ -1,9 +1,9 @@
 using AnchorSafe.API.Helpers;
 using AnchorSafe.API.Services;
 using AnchorSafe.Data;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Data.Entity;
 using System.Linq;
 using System.Net;
@@ -21,11 +21,13 @@ namespace AnchorSafe.API.Controllers
     public class AuthController : ApiController
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private readonly IConfiguration configuration;
         private Int32 ExpiryDuration = -1;    // In minutes
 
         public AuthController()
         {
-            ExpiryDuration = Int32.Parse(ConfigurationManager.AppSettings["AS_API_TokenExpiryDuration"]);
+            configuration = ConfigurationHelper.Configuration;
+            ExpiryDuration = configuration.GetValue<int>("AS_API_TokenExpiryDuration");
         }
 
         /// <summary>

--- a/AnchorSafeWebApi/Controllers/MainController.cs
+++ b/AnchorSafeWebApi/Controllers/MainController.cs
@@ -1,8 +1,9 @@
+using AnchorSafe.API.Helpers;
 using AnchorSafe.Data;
 using AnchorSafe.SimPro;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Data.Entity;
 using System.Linq;
 using System.Net;
@@ -22,14 +23,21 @@ namespace AnchorSafe.API.Controllers
     {
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        private readonly SimProSettings simProSettings = new SimProSettings
+        private readonly IConfiguration configuration;
+        private readonly SimProSettings simProSettings;
+
+        public MainController()
         {
-            Host = ConfigurationManager.AppSettings["SimPro_API_BaseUrl"],
-            Version = ConfigurationManager.AppSettings["SimPro_API_Version"],
-            Key = ConfigurationManager.AppSettings["SimPro_API_Key"],
-            CompanyId = Int32.Parse(ConfigurationManager.AppSettings["SimPro_API_CompanyId"]),
-            CachePath = ConfigurationManager.AppSettings["SimPro_API_CachePath"]
-        };
+            configuration = ConfigurationHelper.Configuration;
+            simProSettings = new SimProSettings
+            {
+                Host = configuration["SimPro_API_BaseUrl"] ?? string.Empty,
+                Version = configuration["SimPro_API_Version"] ?? string.Empty,
+                Key = configuration["SimPro_API_Key"] ?? string.Empty,
+                CompanyId = configuration.GetValue<int>("SimPro_API_CompanyId"),
+                CachePath = configuration["SimPro_API_CachePath"] ?? string.Empty
+            };
+        }
 
         /// <summary>
         /// Simple greeting endpoint.
@@ -136,11 +144,11 @@ namespace AnchorSafe.API.Controllers
                 log.Debug($"User-Agent header: {ua}");
                 if (ua.Contains("iOS"))
                 {
-                    version = ConfigurationManager.AppSettings["AS_App_Latest_iOS"];
+                    version = configuration["AS_App_Latest_iOS"] ?? string.Empty;
                 }
                 else if (ua.Contains("Android"))
                 {
-                    version = ConfigurationManager.AppSettings["AS_App_Latest_Android"];
+                    version = configuration["AS_App_Latest_Android"] ?? string.Empty;
                 }
                 log.Info($"GetLatestAppVersion | Determined version = {version}");
             }

--- a/AnchorSafeWebApi/GlobalUsings.cs
+++ b/AnchorSafeWebApi/GlobalUsings.cs
@@ -1,1 +1,1 @@
-global using ConfigurationManager = System.Configuration.ConfigurationManager;
+// Global using directives for AnchorSafeWebApi project.

--- a/AnchorSafeWebApi/Helpers/App.cs
+++ b/AnchorSafeWebApi/Helpers/App.cs
@@ -1,7 +1,6 @@
 ﻿using AnchorSafe.Data;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using log4net;
 using System.Reflection;
@@ -41,7 +40,7 @@ namespace AnchorSafe.API.Helpers
         public static ApplicationStatus ApplicationMode()
         {
             log.Info("Entering Api.ApplicationMode()");
-            string applicationMode = ConfigurationManager.AppSettings["AS_API_ApplicationMode"];
+            string applicationMode = ConfigurationHelper.Configuration["AS_API_ApplicationMode"] ?? string.Empty;
             log.Debug($"Configuration AS_API_ApplicationMode = '{applicationMode}'");
 
             ApplicationStatus status = applicationMode?.ToLower().Contains("live") == true

--- a/AnchorSafeWebApi/Helpers/ConfigurationHelper.cs
+++ b/AnchorSafeWebApi/Helpers/ConfigurationHelper.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.Extensions.Configuration;
+
+#nullable enable
+
+namespace AnchorSafe.API.Helpers
+{
+    /// <summary>
+    /// Provides access to the application's configuration source.
+    /// </summary>
+    public static class ConfigurationHelper
+    {
+        private static IConfiguration? _configuration;
+
+        /// <summary>
+        /// Stores the application's <see cref="IConfiguration"/> instance for later retrieval.
+        /// </summary>
+        /// <param name="configuration">The configuration instance supplied by the host.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration"/> is <c>null</c>.</exception>
+        public static void Initialize(IConfiguration configuration)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        /// <summary>
+        /// Gets the initialized configuration instance.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when <see cref="Initialize"/> has not been called.</exception>
+        public static IConfiguration Configuration =>
+            _configuration ?? throw new InvalidOperationException("ConfigurationHelper has not been initialized.");
+    }
+}

--- a/AnchorSafeWebApi/Program.cs
+++ b/AnchorSafeWebApi/Program.cs
@@ -1,4 +1,5 @@
 using AnchorSafe.API.Compatibility;
+using AnchorSafe.API.Helpers;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -50,6 +51,8 @@ internal class Program
                 options.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
             }
         });
+
+        ConfigurationHelper.Initialize(builder.Configuration);
 
         var app = builder.Build();
 

--- a/AnchorSafeWebApi/Services/Security.cs
+++ b/AnchorSafeWebApi/Services/Security.cs
@@ -1,6 +1,6 @@
-﻿using AnchorSafe.API.Services;
+using AnchorSafe.API.Helpers;
+using Microsoft.Extensions.Configuration;
 using System;
-using System.Configuration;
 using System.Security.Cryptography;
 using log4net;
 using System.Reflection;
@@ -29,9 +29,10 @@ namespace AnchorSafe.API.Services
             log.Info("Entering Security.Init()");
             try
             {
-                SaltByteLength = Int32.Parse(ConfigurationManager.AppSettings["AS_API_SecSaltByteLength"]);
-                DerivedKeyLength = Int32.Parse(ConfigurationManager.AppSettings["AS_API_SecDerivedKeyLength"]);
-                InterationCount = Int32.Parse(ConfigurationManager.AppSettings["AS_API_SecIterationCount"]);
+                IConfiguration configuration = ConfigurationHelper.Configuration;
+                SaltByteLength = configuration.GetValue<int>("AS_API_SecSaltByteLength");
+                DerivedKeyLength = configuration.GetValue<int>("AS_API_SecDerivedKeyLength");
+                InterationCount = configuration.GetValue<int>("AS_API_SecIterationCount");
                 Initiated = true;
                 log.Debug($"Loaded settings: SaltByteLength={SaltByteLength}, DerivedKeyLength={DerivedKeyLength}, IterationCount={InterationCount}");
                 log.Info("Exiting Security.Init() successfully");

--- a/AnchorSafeWebApi/Services/SimProSyncService.cs
+++ b/AnchorSafeWebApi/Services/SimProSyncService.cs
@@ -1,8 +1,9 @@
-﻿using AnchorSafe.SimPro;
+using AnchorSafe.API.Helpers;
+using AnchorSafe.SimPro;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -165,13 +166,14 @@ namespace AnchorSafe.API.Services
         private void PerformSync(SimProTable tables)
         {
             log.Info($"SimProSyncJob {TaskId}: Entering PerformSync");
+            IConfiguration configuration = ConfigurationHelper.Configuration;
             SimProSettings simProSettings = new SimProSettings
             {
-                Host = ConfigurationManager.AppSettings["SimPro_API_BaseUrl"],
-                Version = ConfigurationManager.AppSettings["SimPro_API_Version"],
-                Key = ConfigurationManager.AppSettings["SimPro_API_Key"],
-                CompanyId = Int32.Parse(ConfigurationManager.AppSettings["SimPro_API_CompanyId"]),
-                CachePath = ConfigurationManager.AppSettings["SimPro_API_CachePath"]
+                Host = configuration["SimPro_API_BaseUrl"] ?? string.Empty,
+                Version = configuration["SimPro_API_Version"] ?? string.Empty,
+                Key = configuration["SimPro_API_Key"] ?? string.Empty,
+                CompanyId = configuration.GetValue<int>("SimPro_API_CompanyId"),
+                CachePath = configuration["SimPro_API_CachePath"] ?? string.Empty
             };
 
             if (tables.HasFlag(SimProTable.Clients))

--- a/AnchorSafeWebApi/Services/TokenService.cs
+++ b/AnchorSafeWebApi/Services/TokenService.cs
@@ -1,8 +1,7 @@
-﻿using AnchorSafe.API.Helpers;
+using AnchorSafe.API.Helpers;
 using log4net;
 using Microsoft.IdentityModel.Tokens;
 using System;
-using System.Configuration;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Reflection;
@@ -47,7 +46,8 @@ namespace AnchorSafe.API.Services
             string jwt = null;
             try
             {
-                byte[] key = Convert.FromBase64String(ConfigurationManager.AppSettings["AS_API_TokenSecret"]);
+                string secret = ConfigurationHelper.Configuration["AS_API_TokenSecret"] ?? string.Empty;
+                byte[] key = Convert.FromBase64String(secret);
                 log.Debug("Decoded token secret key from configuration");
 
                 SymmetricSecurityKey securityKey = new SymmetricSecurityKey(key);
@@ -95,7 +95,8 @@ namespace AnchorSafe.API.Services
 
                 Boolean validateExpiration = !Api.IsApplicationDevMode();
 
-                byte[] key = Convert.FromBase64String(ConfigurationManager.AppSettings["AS_API_TokenSecret"]);
+                string secret = ConfigurationHelper.Configuration["AS_API_TokenSecret"] ?? string.Empty;
+                byte[] key = Convert.FromBase64String(secret);
                 TokenValidationParameters parameters = new TokenValidationParameters
                 {
                     RequireExpirationTime = validateExpiration,
@@ -158,7 +159,7 @@ namespace AnchorSafe.API.Services
 
             if (String.IsNullOrWhiteSpace(username) && Api.IsApplicationDevMode())
             {
-                username = ConfigurationManager.AppSettings["AS_API_DevModeNullUser"];
+                username = ConfigurationHelper.Configuration["AS_API_DevModeNullUser"];
                 if (!String.IsNullOrWhiteSpace(username))
                 {
                     log.Warn($"API is in Dev mode and is returning a default username '{username}'");

--- a/AnchorSafeWebApi/appsettings.json
+++ b/AnchorSafeWebApi/appsettings.json
@@ -5,5 +5,32 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "SiteSqlServer": ""
+  },
+  "AS_API_ApplicationMode": "Dev",
+  "SimPro_API_BaseUrl": "",
+  "SimPro_API_Version": "",
+  "SimPro_API_Key": "",
+  "SimPro_API_CompanyId": 0,
+  "SimPro_API_CachePath": "",
+  "AS_App_Latest_iOS": "",
+  "AS_App_Latest_Android": "",
+  "AS_API_CronToken": "",
+  "AS_API_AdminUserId": 0,
+  "AS_API_UnassignedUserId": 0,
+  "AS_API_WebMatrixUserId": 0,
+  "AS_API_ImageSaveFilePath": "",
+  "AS_API_UnassignedStatus": 0,
+  "AS_API_DataSaveFilePath": "",
+  "AS_API_BaseUrl": "",
+  "AS_API_TokenExpiryDuration": 0,
+  "AS_API_ForceSync": false,
+  "AS_API_ForceSyncDate": "",
+  "AS_API_TokenSecret": "AAAAAAAAAAAAAAAAAAAAAA==",
+  "AS_API_DevModeNullUser": "",
+  "AS_API_SecSaltByteLength": 0,
+  "AS_API_SecDerivedKeyLength": 0,
+  "AS_API_SecIterationCount": 0
 }

--- a/GlobalUsings.cs
+++ b/GlobalUsings.cs
@@ -1,2 +1,1 @@
-global using ConfigurationManager = System.Configuration.ConfigurationManager;
 global using IHttpActionResult = Microsoft.AspNetCore.Mvc.IActionResult;


### PR DESCRIPTION
## Summary
- add a configuration helper that stores the host-provided IConfiguration and initialize it during startup
- update controllers and services to read settings and connection strings through IConfiguration instead of ConfigurationManager
- define the legacy app settings and connection string entries inside appsettings.json

## Testing
- dotnet build AnchorSafeWebApi/AnchorSafeWebApi.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d1e91b2c40832eaa810f29ac3f2f4a